### PR TITLE
fix: 修复镜像更新由于文件持久化不会更新的问题

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -eu
 
-if [ ! -e '/var/www/html/public/index.php' ]; then
-    cp -a /var/www/lsky/* /var/www/html/
-    cp -a /var/www/lsky/.env.example /var/www/html
+if [ -e '/var/www/lsky' ]; then
+    cp -af /var/www/lsky/* /var/www/html/
+    cp -af /var/www/lsky/.env.example /var/www/html
+    rm -rf /var/www/lsky
 fi
     chown -R www-data /var/www/html
     chgrp -R www-data /var/www/html


### PR DESCRIPTION
修改前：首次安装时由于不存在index.php，会把项目文件拷贝到html这没问题。但后续如果项目更新了，此时更新容器则会发现index.php依然存在，而不把新的项目文件拷贝过去。
修改后：首次安装时存在lsky，直接把lsky移动到html（删除lsky）。后续项目更新了，更新容器时新建的容器会产生新的lsky，从而把更新的项目文件移动过去。